### PR TITLE
Update to make this package compatible with Laravel 5.5

### DIFF
--- a/src/CodeSnifferCommand.php
+++ b/src/CodeSnifferCommand.php
@@ -46,7 +46,7 @@ class CodeSnifferCommand extends Command
     /**
      * Handle the command
      */
-    public function fire()
+    public function handle()
     {
         $environment = $this->config->get('app.env');
         $gitSnifferEnv = $this->config->get('git-sniffer.env');


### PR DESCRIPTION
Laravel 5.5 LTS deprecates the `fire` command and you use `handle` instead.