### PR TITLE
Add Laravel 5.5 autodiscovery capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An artisan command to check your code standards via pre-commit git hook
 composer require avirdz/laravel-git-sniffer
 ```
 
-#### Add the provider to app config
+#### Add the provider to app config (You don't need to do this if using Laravel >= 5.5)
 ```sh
 Avirdz\LaravelGitSniffer\GitSnifferServiceProvider
 ```

--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,12 @@
         "psr-4": {
             "Avirdz\\LaravelGitSniffer\\": "src"
         }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Avirdz\\LaravelGitSniffer\\GitSnifferServiceProvider"
+            ]
+        }
     }
 }


### PR DESCRIPTION
As of Laravel 5.5 new feature **Package Auto-Discovery** we can add service provider auto registration
https://laravel-news.com/package-auto-discovery , this way the installation is a little more easy.
